### PR TITLE
Add documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+Files in `src/` are loaded when generating the WriteVTK.jl documentation.
+
+See [WriteVTK/docs/make.jl](https://github.com/JuliaVTK/WriteVTK.jl/tree/master/docs/make.jl) for details.

--- a/docs/src/VTKBase.md
+++ b/docs/src/VTKBase.md
@@ -1,0 +1,10 @@
+# VTKBase.jl
+
+The [VTKBase.jl](https://github.com/JuliaVTK/VTKBase.jl) package contains
+common definitions used in the
+[WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl) and
+[ReadVTK.jl](https://github.com/JuliaVTK/ReadVTK.jl) packages.
+
+```@autodocs
+Modules = [VTKBase]
+```

--- a/docs/src/VTKBase.md
+++ b/docs/src/VTKBase.md
@@ -5,6 +5,55 @@ common definitions used in the
 [WriteVTK.jl](https://github.com/JuliaVTK/WriteVTK.jl) and
 [ReadVTK.jl](https://github.com/JuliaVTK/ReadVTK.jl) packages.
 
-```@autodocs
-Modules = [VTKBase]
+## VTK dataset types
+
+```@docs
+AbstractVTKDataset
+StructuredVTKDataset
+VTKImageData
+VTKRectilinearGrid
+VTKStructuredGrid
+UnstructuredVTKDataset
+VTKPolyData
+VTKUnstructuredGrid
+```
+
+## Field data types
+
+In VTK, data can either be attached to the geometry (point and cell data), or
+not (field data).
+
+```@docs
+VTKBase.AbstractFieldData
+VTKPointData
+VTKCellData
+VTKFieldData
+```
+
+## Cells in unstructured grids
+
+### General unstructured datasets
+
+These are useful when working with general unstructured datasets (`.vtu` files).
+
+```@docs
+VTKCellTypes
+VTKCellTypes.nodes
+VTKBase.AbstractMeshCell
+MeshCell
+```
+
+### Polygonal datasets
+
+These are useful when working with polygonal datasets (`.vtp` files).
+
+```@docs
+PolyData
+VTKPolyhedron
+```
+
+## Constants
+
+```@docs
+VTKBase.VTKDataType
 ```

--- a/src/VTKBase.jl
+++ b/src/VTKBase.jl
@@ -7,7 +7,7 @@ export VTKCellTypes, VTKCellType
 """
     VTKDataType
 
-Union of data types allowed by VTK.
+Union of integer, float and string data types allowed by VTK.
 """
 const VTKDataType = Union{Int8, UInt8, Int16, UInt16, Int32, UInt32,
                           Int64, UInt64, Float32, Float64, String}

--- a/src/mesh_cells.jl
+++ b/src/mesh_cells.jl
@@ -41,7 +41,7 @@ module;
 - cell types for polygonal datasets are defined in the [`PolyData`](@ref) module.
 
 The `connectivity` argument is a vector or tuple containing the indices of the
-points passed to [`vtk_grid`](@ref) which define this cell.
+points passed to `vtk_grid` which define this cell.
 
 # Example
 


### PR DESCRIPTION
This PR basically adds the file `docs/src/VTKBase.md`, which should be sourced by other package's documentations to display docs for VTKBase.jl definitions. Docs in WriteVTK.jl will be changed to reflect these changes.