### PR TITLE
add missing exports from docs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "VTKBase"
 uuid = "4004b06d-e244-455f-a6ce-a5f9919cc534"
 authors = ["Juan Ignacio Polanco <juan-ignacio.polanco@cnrs.fr>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1.6"

--- a/src/VTKBase.jl
+++ b/src/VTKBase.jl
@@ -43,6 +43,8 @@ strings.
 """
 struct VTKFieldData <: AbstractFieldData end
 
+export VTKPointData, VTKCellData, VTKFieldData
+
 # These are the VTK names associated to each data "location".
 node_type(::VTKPointData) = "PointData"
 node_type(::VTKCellData) = "CellData"

--- a/src/polydata.jl
+++ b/src/polydata.jl
@@ -40,6 +40,8 @@ end
 
 import .PolyData
 
+export PolyData
+
 const PolyCell{T} = MeshCell{T} where {T <: PolyData.CellType}
 
 Base.eltype(::Type{T}) where {T <: PolyCell} = cell_type(T)


### PR DESCRIPTION
I added some `export` statements for things referenced in the docs without `VTKBase` prefix. Either this or adding the prefix is required to build the docs for ReadVTK.jl in https://github.com/JuliaVTK/ReadVTK.jl/pull/26